### PR TITLE
chore(deps): bump rustls-pki-types to 1.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ tokio-native-tls = { version = "0.3.0", optional = true }
 # rustls-tls
 hyper-rustls = { version = "0.27.0", default-features = false, optional = true, features = ["http1", "tls12"] }
 rustls = { version = "0.23.4", optional = true, default-features = false, features = ["std", "tls12"] }
-rustls-pki-types = { version = "1.1.0", features = ["alloc"] ,optional = true }
+rustls-pki-types = { version = "1.11.0", features = ["alloc"], optional = true } 
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }
 webpki-roots = { version = "0.26.0", optional = true }
 rustls-native-certs = { version = "0.8.0", optional = true }


### PR DESCRIPTION
Bump `rustls-pki-types` to v1.11.0.
This is needed to upgrade `sentry-rust` in Symbolicator due to the recent upgrade of `ureq` to v3 in `sentry-rust`: https://github.com/getsentry/sentry-rust/pull/835

Tested by running the tests in this repo and in symbolicator with this branch