### PR TITLE
ci: pin any version of `hashbrown` to 0.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,7 @@ jobs:
           cargo update -p tokio --precise 1.29.1
           cargo update -p tokio-util --precise 0.7.11
           cargo update -p idna_adapter --precise 1.1.0
-          cargo update -p hashbrown@0.15.2 --precise 0.15.0
+          cargo update -p hashbrown --precise 0.15.0
           cargo update -p native-tls --precise 0.2.13
           cargo update -p once_cell --precise 1.20.3
 


### PR DESCRIPTION
Replicates https://github.com/seanmonstar/reqwest/pull/2666 to make the MSRV check pass.